### PR TITLE
Add nutrition Telegram bot example

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,3 @@
+TELEGRAM_BOT_TOKEN=your-telegram-bot-token
+GIGACHAT_CLIENT_ID=your-gigachat-client-id
+GIGACHAT_CLIENT_SECRET=your-gigachat-client-secret

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.env

--- a/README.md
+++ b/README.md
@@ -124,3 +124,13 @@ Dan Korn, [@DnlRKorn](https://github.com/DnlRKorn)
 Chris Brown, [@CryoBrown](https://github.com/CryoBrown)
 
 Cannon Lewis, [@cannon10100](https://github.com/cannon10100)
+
+## Nutrition Bot
+
+This repository now includes a simple Telegram bot in `nutrition_bot/` that demonstrates how to build a diet assistant. It uses `python-telegram-bot` and a GigaChat client for meal planning. Configure the required tokens in a `.env` file based on `.env.template` and install dependencies from `requirements.txt`.
+
+Start the bot with:
+
+```bash
+python -m nutrition_bot.bot
+```

--- a/nutrition_bot/__init__.py
+++ b/nutrition_bot/__init__.py
@@ -1,0 +1,1 @@
+"""Simple diet bot module."""

--- a/nutrition_bot/bot.py
+++ b/nutrition_bot/bot.py
@@ -1,0 +1,142 @@
+import logging
+import os
+from dotenv import load_dotenv
+from telegram import Update, ReplyKeyboardMarkup, ReplyKeyboardRemove
+from telegram.ext import (
+    ApplicationBuilder,
+    CommandHandler,
+    ContextTypes,
+    ConversationHandler,
+    MessageHandler,
+    filters,
+)
+
+from .giga_api import GigaChatClient
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+(
+    AGE,
+    GENDER,
+    WEIGHT,
+    HEIGHT,
+    ACTIVITY,
+    WORKOUTS,
+    PREFERENCES,
+    ALLERGIES,
+    FASTING,
+    SUMMARY,
+) = range(10)
+
+load_dotenv()
+
+TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+GIGACHAT_CLIENT_ID = os.getenv("GIGACHAT_CLIENT_ID")
+GIGACHAT_CLIENT_SECRET = os.getenv("GIGACHAT_CLIENT_SECRET")
+
+giga_client = GigaChatClient(GIGACHAT_CLIENT_ID, GIGACHAT_CLIENT_SECRET)
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    await update.message.reply_text(
+        "Здравствуйте! Давайте подберем ваш рацион. Сколько вам лет?"
+    )
+    return AGE
+
+async def age(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    context.user_data["age"] = update.message.text
+    reply_keyboard = [["Мужской", "Женский"]]
+    await update.message.reply_text(
+        "Ваш пол?",
+        reply_markup=ReplyKeyboardMarkup(reply_keyboard, one_time_keyboard=True),
+    )
+    return GENDER
+
+async def gender(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    context.user_data["gender"] = update.message.text
+    await update.message.reply_text("Ваш вес (кг)?", reply_markup=ReplyKeyboardRemove())
+    return WEIGHT
+
+async def weight(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    context.user_data["weight"] = update.message.text
+    await update.message.reply_text("Ваш рост (см)?")
+    return HEIGHT
+
+async def height(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    context.user_data["height"] = update.message.text
+    reply_keyboard = [["Сидячая", "Стоячая"]]
+    await update.message.reply_text(
+        "Характер работы?",
+        reply_markup=ReplyKeyboardMarkup(reply_keyboard, one_time_keyboard=True),
+    )
+    return ACTIVITY
+
+async def activity(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    context.user_data["activity"] = update.message.text
+    await update.message.reply_text("Сколько тренировок в неделю?")
+    return WORKOUTS
+
+async def workouts(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    context.user_data["workouts"] = update.message.text
+    await update.message.reply_text("Пищевые предпочтения?")
+    return PREFERENCES
+
+async def preferences(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    context.user_data["preferences"] = update.message.text
+    await update.message.reply_text("Есть ли аллергии?")
+    return ALLERGIES
+
+async def allergies(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    context.user_data["allergies"] = update.message.text
+    reply_keyboard = [["Да", "Нет"]]
+    await update.message.reply_text(
+        "Интересует интервальное голодание?",
+        reply_markup=ReplyKeyboardMarkup(reply_keyboard, one_time_keyboard=True),
+    )
+    return FASTING
+
+async def fasting(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    context.user_data["fasting"] = update.message.text
+    summary = "\n".join(f"{k}: {v}" for k, v in context.user_data.items())
+    prompt = f"Составь рацион по данным:\n{summary}"
+    plan = giga_client.generate(prompt)
+    await update.message.reply_text(
+        f"Ваш индивидуальный рацион:\n{plan}", reply_markup=ReplyKeyboardRemove()
+    )
+    return ConversationHandler.END
+
+async def cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    await update.message.reply_text(
+        "Диалог прерван.", reply_markup=ReplyKeyboardRemove()
+    )
+    return ConversationHandler.END
+
+
+def main() -> None:
+    if not TELEGRAM_BOT_TOKEN:
+        raise RuntimeError("TELEGRAM_BOT_TOKEN not set")
+
+    app = ApplicationBuilder().token(TELEGRAM_BOT_TOKEN).build()
+
+    conv_handler = ConversationHandler(
+        entry_points=[CommandHandler("start", start)],
+        states={
+            AGE: [MessageHandler(filters.TEXT & ~filters.COMMAND, age)],
+            GENDER: [MessageHandler(filters.TEXT & ~filters.COMMAND, gender)],
+            WEIGHT: [MessageHandler(filters.TEXT & ~filters.COMMAND, weight)],
+            HEIGHT: [MessageHandler(filters.TEXT & ~filters.COMMAND, height)],
+            ACTIVITY: [MessageHandler(filters.TEXT & ~filters.COMMAND, activity)],
+            WORKOUTS: [MessageHandler(filters.TEXT & ~filters.COMMAND, workouts)],
+            PREFERENCES: [MessageHandler(filters.TEXT & ~filters.COMMAND, preferences)],
+            ALLERGIES: [MessageHandler(filters.TEXT & ~filters.COMMAND, allergies)],
+            FASTING: [MessageHandler(filters.TEXT & ~filters.COMMAND, fasting)],
+        },
+        fallbacks=[CommandHandler("cancel", cancel)],
+    )
+
+    app.add_handler(conv_handler)
+    logger.info("Bot started")
+    app.run_polling()
+
+if __name__ == "__main__":
+    main()

--- a/nutrition_bot/giga_api.py
+++ b/nutrition_bot/giga_api.py
@@ -1,0 +1,23 @@
+import os
+import requests
+
+GIGA_ENDPOINT = os.getenv("GIGACHAT_URL", "https://api.gigachat.com/v1/chat")
+
+class GigaChatClient:
+    def __init__(self, client_id: str, client_secret: str):
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+    def generate(self, prompt: str) -> str:
+        try:
+            response = requests.post(
+                GIGA_ENDPOINT,
+                json={"prompt": prompt},
+                auth=(self.client_id, self.client_secret),
+                timeout=30,
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data.get("response", "")
+        except Exception as e:
+            return f"Error contacting GigaChat: {e}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+python-telegram-bot==20.7
+python-dotenv
+requests


### PR DESCRIPTION
## Summary
- ignore .env files
- add template for environment variables
- implement `nutrition_bot` Telegram bot using python-telegram-bot
- provide GigaChat client example
- document how to run the bot and added requirements file

## Testing
- `python -m py_compile nutrition_bot/*.py`
- `pytest` *(0 tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_684eeb51824c8328ad92fac6248a4e2d